### PR TITLE
Fix invalid preprocessor token name

### DIFF
--- a/SmartLCDI2C.cpp
+++ b/SmartLCDI2C.cpp
@@ -310,7 +310,7 @@ void SmartLCD::ClearButton(void)
 		NOTE_G			7
 		NOTE_GS			8
 		NOTE_A			9
-		NOTE_A#			10
+		NOTE_AS			10
 		NOTE_B			11
 		
 		Time is the duration of the note in 10ms increments (1 = 10ms to 255 = 2.55s)

--- a/SmartLCDI2C.h
+++ b/SmartLCDI2C.h
@@ -63,7 +63,7 @@ REASON WHATSOEVER.
 #define NOTE_G			7
 #define NOTE_GS			8
 #define NOTE_A			9
-#define NOTE_A#			10
+#define NOTE_AS			10
 #define NOTE_B			11
 
 


### PR DESCRIPTION
Using the `#` character as part of a token name is not valid. Can you please merge this?