### PR TITLE
Fix compiler error due to lack of pointer constness

### DIFF
--- a/SmartLCDI2C.cpp
+++ b/SmartLCDI2C.cpp
@@ -93,7 +93,7 @@ void SmartLCD::PrintChar(char Character)
 /* Prints a string of ASCII text to the screen where:
 		String is an ASCII string with null terminator containing the text to print
 */
-void SmartLCD::Print(char *String)
+void SmartLCD::Print(const char *String)
 {
 	uint8_t i = 0;
 
@@ -240,7 +240,7 @@ void SmartLCD::PrintCustChar(uint8_t CharIndex)
 	Note after issuing this function you must reposition the cursor before printing any text
 	using the SmartLCD.CurPos(Row, Col) function.
 */
-void SmartLCD::DefCustChar(uint8_t CharIndex, uint8_t *Data)
+void SmartLCD::DefCustChar(uint8_t CharIndex, const uint8_t *Data)
 {
 	Wire.beginTransmission(_I2C_Add);
 	Wire.write(I2CDEFINECUSTOM);

--- a/SmartLCDI2C.cpp
+++ b/SmartLCDI2C.cpp
@@ -3,19 +3,19 @@
    VERSION: 0.1
    AUTHOR:  Andrew Davies
    WEBSITE: HobbyComponents.com
-   
+
 12/07/17 version 0.1: Original version
 
 Arduino I2C library for the Hobby Components Smart LCD.
 Products currently supported by this library:
 
-Hobby Components 1602 Smart LCD (HCMODU0122) available from hobbycomponents.com 
+Hobby Components 1602 Smart LCD (HCMODU0122) available from hobbycomponents.com
 
 Optional:
 
 Hobby Components SmartLCD Keypad kit (HCKITS0058)
 
-More information about this library can be found in the software section of our support 
+More information about this library can be found in the software section of our support
 forum here:
 
 http://forum.hobbycomponents.com/software
@@ -56,7 +56,7 @@ REASON WHATSOEVER.
 
 
 /* I2C Constructor to initialise the library where:
-   
+
    I2C_Add is the I2C address of the SmartLCD.
 		Valid values for I2C_Add are 0x08 to 0x77 (default = 0x27)
 */
@@ -71,32 +71,32 @@ SmartLCD::SmartLCD(uint8_t I2C_Add)
 void SmartLCD::init(void)
 {
 	//Initiliase the I2C interface
-	Wire.begin(); 
+	Wire.begin();
 }
 
 
 
 /* Prints a single ASCII character to the screen where:
-		Character is the ASCII encoded character to print 
+		Character is the ASCII encoded character to print
 */
 void SmartLCD::PrintChar(char Character)
 {
 	Wire.beginTransmission(_I2C_Add);
-	Wire.write(I2CPRINTCHAR); 
+	Wire.write(I2CPRINTCHAR);
 	Wire.write(Character);
-	Wire.endTransmission(); 
+	Wire.endTransmission();
 	while(Busy());
 }
 
 
 
 /* Prints a string of ASCII text to the screen where:
-		String is an ASCII string with null terminator containing the text to print 
+		String is an ASCII string with null terminator containing the text to print
 */
 void SmartLCD::Print(char *String)
 {
 	uint8_t i = 0;
-	
+
 	while(String[i] != '\0')
 	{
 		PrintChar(String[i]);
@@ -107,26 +107,26 @@ void SmartLCD::Print(char *String)
 
 
 /* Prints a signed integer number to the screen where:
-		Value is the signed integer to print 
+		Value is the signed integer to print
 */
 void SmartLCD::Print(int Value)
 {
 	char buffer[12];
-	
-	itoa(Value,buffer,10);	
+
+	itoa(Value,buffer,10);
 	Print(buffer);
 }
 
 
 
-/* Clears the screen of any printed text and positions the cursor to row 0, 
+/* Clears the screen of any printed text and positions the cursor to row 0,
    column 0 (top left hand corner)
 */
 void SmartLCD::Clear(void)
 {
 	Wire.beginTransmission(_I2C_Add);
-	Wire.write(I2CCLEAR); 
-	Wire.endTransmission(); 
+	Wire.write(I2CCLEAR);
+	Wire.endTransmission();
 	while(Busy());
 }
 
@@ -134,16 +134,16 @@ void SmartLCD::Clear(void)
 
 /* Positions the cursor on the screen where:
 		Row is the text row number - valid values are 0 to 4 (only 0 to 1 visible on 1602 version)
-		
+
 		Col is the text column number - valid values are 0 to 79 (only 0 to 15 visible on 1602 version)
 */
 void SmartLCD::CurPos(uint8_t Row, uint8_t Col)
 {
 	Wire.beginTransmission(_I2C_Add);
-	Wire.write(I2CCURPOS); 
+	Wire.write(I2CCURPOS);
 	Wire.write(Row);
-	Wire.write(Col);  
-	Wire.endTransmission(); 
+	Wire.write(Col);
+	Wire.endTransmission();
 	while(Busy());
 }
 
@@ -153,15 +153,15 @@ void SmartLCD::CurPos(uint8_t Row, uint8_t Col)
 		State is required state to set the screen to. Valid values are
 		OFF (screen is turned off)
 		ON 	(screen is turned on)
-		
+
 	Note that any text on the screen and the backlight state are not affected.
 */
 void SmartLCD::DispState(uint8_t State)
 {
 	Wire.beginTransmission(_I2C_Add);
-	Wire.write(I2CDISPLAYSTATE); 
+	Wire.write(I2CDISPLAYSTATE);
 	Wire.write(State);
-	Wire.endTransmission(); 
+	Wire.endTransmission();
 	while(Busy());
 }
 
@@ -171,13 +171,13 @@ void SmartLCD::DispState(uint8_t State)
 		State is required state to set the cursor to. Valid values are
 		OFF (cursor is turned off)
 		ON 	(cursor is turned on)
-*/		
+*/
 void SmartLCD::DispCursor(uint8_t State)
 {
 	Wire.beginTransmission(_I2C_Add);
-	Wire.write(I2CDISPLAYCUR); 
+	Wire.write(I2CDISPLAYCUR);
 	Wire.write(State);
-	Wire.endTransmission(); 
+	Wire.endTransmission();
 	while(Busy());
 }
 
@@ -191,9 +191,9 @@ void SmartLCD::DispCursor(uint8_t State)
 void SmartLCD::CursorBlink(uint8_t State)
 {
 	Wire.beginTransmission(_I2C_Add);
-	Wire.write(I2CCURBLINK); 
+	Wire.write(I2CCURBLINK);
 	Wire.write(State);
-	Wire.endTransmission(); 
+	Wire.endTransmission();
 	while(Busy());
 }
 
@@ -208,9 +208,9 @@ void SmartLCD::Backlight(uint8_t Level)
 	if(Level > 10)
 		Level = 10;
 	Wire.beginTransmission(_I2C_Add);
-	Wire.write(I2CBACKLIGHT); 
+	Wire.write(I2CBACKLIGHT);
 	Wire.write(Level);
-	Wire.endTransmission(); 
+	Wire.endTransmission();
 }
 
 
@@ -218,13 +218,13 @@ void SmartLCD::Backlight(uint8_t Level)
 /* Prints one of the 8 custom characters to the screen where:
 		CharIndex specifies which custom character (0 to 7) to print.
 */
-		
+
 void SmartLCD::PrintCustChar(uint8_t CharIndex)
 {
 	Wire.beginTransmission(_I2C_Add);
-	Wire.write(I2CPRINTCUSTOM); 
-	Wire.write(CharIndex); 
-	Wire.endTransmission(); 
+	Wire.write(I2CPRINTCUSTOM);
+	Wire.write(CharIndex);
+	Wire.endTransmission();
 	while(Busy());
 }
 
@@ -232,28 +232,28 @@ void SmartLCD::PrintCustChar(uint8_t CharIndex)
 
 /* Defines one of the 8 custom characters by writing a 5x8 pixel bitmap to it where:
 		CharIndex specifies which custom character (0 to 7) to write the bitmap to.
-		
-		Data is an 8 byte array containing the bitmap data. 
-		
+
+		Data is an 8 byte array containing the bitmap data.
+
 	See the Smart LCD manual for more information on bitmap format.
-	
+
 	Note after issuing this function you must reposition the cursor before printing any text
 	using the SmartLCD.CurPos(Row, Col) function.
 */
 void SmartLCD::DefCustChar(uint8_t CharIndex, uint8_t *Data)
 {
 	Wire.beginTransmission(_I2C_Add);
-	Wire.write(I2CDEFINECUSTOM); 
-	Wire.write(CharIndex); 
-	Wire.write(Data[0]); 
-	Wire.write(Data[1]); 
-	Wire.write(Data[2]); 
-	Wire.write(Data[3]); 
-	Wire.write(Data[4]); 
-	Wire.write(Data[5]); 
+	Wire.write(I2CDEFINECUSTOM);
+	Wire.write(CharIndex);
+	Wire.write(Data[0]);
+	Wire.write(Data[1]);
+	Wire.write(Data[2]);
+	Wire.write(Data[3]);
+	Wire.write(Data[4]);
+	Wire.write(Data[5]);
 	Wire.write(Data[6]);
 	Wire.write(Data[7]);
-	Wire.endTransmission(); 
+	Wire.endTransmission();
 	while(Busy());
 }
 
@@ -267,21 +267,21 @@ void SmartLCD::DefCustChar(uint8_t CharIndex, uint8_t *Data)
 void SmartLCD::CursorDir(uint8_t Dir)
 {
 	Wire.beginTransmission(_I2C_Add);
-	Wire.write(I2CCURDIR); 
+	Wire.write(I2CCURDIR);
 	Wire.write(Dir);
-	Wire.endTransmission(); 
+	Wire.endTransmission();
 	while(Busy());
 }
 
 
 
-/* Initialises the LCD setting it to its default power on state. If the 
+/* Initialises the LCD setting it to its default power on state. If the
    backlight was off it will also be set to the default on state. */
 void SmartLCD::I2CInit(void)
 {
 	Wire.beginTransmission(_I2C_Add);
-	Wire.write(I2CINIT); 
-	Wire.endTransmission(); 
+	Wire.write(I2CINIT);
+	Wire.endTransmission();
 	while(Busy());
 }
 
@@ -291,8 +291,8 @@ void SmartLCD::I2CInit(void)
 void SmartLCD::ClearButton(void)
 {
 	Wire.beginTransmission(_I2C_Add);
-	Wire.write(I2CCLEARBUTTON); 
-	Wire.endTransmission(); 
+	Wire.write(I2CCLEARBUTTON);
+	Wire.endTransmission();
 	while(Busy());
 }
 
@@ -312,12 +312,12 @@ void SmartLCD::ClearButton(void)
 		NOTE_A			9
 		NOTE_AS			10
 		NOTE_B			11
-		
+
 		Time is the duration of the note in 10ms increments (1 = 10ms to 255 = 2.55s)
 
    Note: Requires the optional keypad and speaker accessory to be connected to
    the Smart LCD.
-   
+
    This command is none blocking - i.e. it will not wait for the note to finish playing.
 */
 void SmartLCD::PlayNote(uint8_t Note, uint8_t Time)
@@ -325,10 +325,10 @@ void SmartLCD::PlayNote(uint8_t Note, uint8_t Time)
 	if(Note > 11)
 		Note = 11;
 	Wire.beginTransmission(_I2C_Add);
-	Wire.write(I2CPLAYNOTE); 
+	Wire.write(I2CPLAYNOTE);
 	Wire.write(Note);
-	Wire.write(Time);  
-	Wire.endTransmission(); 
+	Wire.write(Time);
+	Wire.endTransmission();
 	while(Busy());
 }
 
@@ -337,19 +337,19 @@ void SmartLCD::PlayNote(uint8_t Note, uint8_t Time)
 /* Changes the I2C slave address for the Smart LCD where:
 		Address is the new I2C address. Valid values are
 		0x08 to 0x77 (default =0x27)
-		
-   Note: Once this command is issued the display will immediately respond to 
-   commands sent to the new slave address and will no longer respond to the 
-   original address. This command will also update the current I2C address 
-   stored within the library so you can continue to issue commands without 
+
+   Note: Once this command is issued the display will immediately respond to
+   commands sent to the new slave address and will no longer respond to the
+   original address. This command will also update the current I2C address
+   stored within the library so you can continue to issue commands without
    needing to re-initialise the library.
 */
 void SmartLCD::Address(uint8_t Address)
 {
 	Wire.beginTransmission(_I2C_Add);
-	Wire.write(I2CADDRESS); 
+	Wire.write(I2CADDRESS);
 	Wire.write(Address);
-	Wire.endTransmission(); 
+	Wire.endTransmission();
 
 	_I2C_Add = Address;
 	while(Busy());
@@ -364,22 +364,22 @@ void SmartLCD::Address(uint8_t Address)
 void SmartLCD::Contrast(uint8_t Level)
 {
 	Wire.beginTransmission(_I2C_Add);
-	Wire.write(I2CCONTRAST); 
+	Wire.write(I2CCONTRAST);
 	Wire.write(Level);
-	Wire.endTransmission(); 
+	Wire.endTransmission();
 	while(Busy());
 }
 
 
 
 /* Shows the version of firmware flashed into the Smart LCD by displaying it to
-   the LCD. 
+   the LCD.
 */
 void SmartLCD::Version(void)
 {
 	Wire.beginTransmission(_I2C_Add);
-	Wire.write(I2CVERSION); 
-	Wire.endTransmission(); 
+	Wire.write(I2CVERSION);
+	Wire.endTransmission();
 	while(Busy());
 }
 
@@ -389,8 +389,8 @@ void SmartLCD::Version(void)
 void SmartLCD::ClearError(void)
 {
 	Wire.beginTransmission(_I2C_Add);
-	Wire.write(I2CCLEARERROR); 
-	Wire.endTransmission(); 
+	Wire.write(I2CCLEARERROR);
+	Wire.endTransmission();
 	while(Busy());
 }
 
@@ -398,19 +398,19 @@ void SmartLCD::ClearError(void)
 
 /* Draws a horizontal wait bar to the screen where:
 		Row is the text row number to position the wait bar.
-		
+
 		Col is the text col number to position the left side of the wait bar.
-		
+
 		Length is the length in characters of the wait bar
-		
+
 		Percent specifies what part of the wait bar to fill in percent (0 to 100)
-*/	
+*/
 void SmartLCD::WaitBar(uint8_t Row, uint8_t Col, uint8_t Length, uint8_t Percent)
 {
 	uint8_t WaitBarEnd[] = {0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00};
-	
-	uint16_t Scale = ((Length * 5) * Percent) / 100; 
-	
+
+	uint16_t Scale = ((Length * 5) * Percent) / 100;
+
 	//First draw any full character blocks
 	CurPos(Row, Col);
 	do
@@ -420,13 +420,13 @@ void SmartLCD::WaitBar(uint8_t Row, uint8_t Col, uint8_t Length, uint8_t Percent
 			PrintChar(0xFF);
 			Scale -= 5;
 			Col++;
-		}	
+		}
 	}while(Scale >= 5);
-	
+
 	uint8_t Pixel = 0x10;
-	
-	
-	/* For the last character block it may only be partially filled so use a 
+
+
+	/* For the last character block it may only be partially filled so use a
 	   custom character and draw the last filled columns within the character */
 	if(Scale)
 	{
@@ -447,19 +447,19 @@ void SmartLCD::WaitBar(uint8_t Row, uint8_t Col, uint8_t Length, uint8_t Percent
 
 
 
-/* Returns the busy status flag where 
-   false = SmartLCD is not busy and can accept new commands 
-   true = SmartLCD is busy and cannot accept new commands 
+/* Returns the busy status flag where
+   false = SmartLCD is not busy and can accept new commands
+   true = SmartLCD is busy and cannot accept new commands
 
-   Note that all the functions within this library use the busy command and 
-   will not finish executing until the SmartLCD has finished processing the 
-   current command. Therefore you do not need to use this function to check 
-   if it is ok to send another command when using the functions within this 
+   Note that all the functions within this library use the busy command and
+   will not finish executing until the SmartLCD has finished processing the
+   current command. Therefore you do not need to use this function to check
+   if it is ok to send another command when using the functions within this
    library.
 */
 boolean SmartLCD::Busy(void)
 {
-	return Status() & STATUS_BUSY; 
+	return Status() & STATUS_BUSY;
 }
 
 
@@ -467,13 +467,13 @@ boolean SmartLCD::Busy(void)
 /* Returns the command error flag where
    false = Last command executed without error
    true = There was an error with executing or receiving the last command.
-   
-   Note that if the error flag is set it will not automatically clear. Therefore 
-   you must clear the flag using the SmartLCD.ClearError() function. 
+
+   Note that if the error flag is set it will not automatically clear. Therefore
+   you must clear the flag using the SmartLCD.ClearError() function.
 */
 boolean SmartLCD::Error(void)
 {
-	return Status() & STATUS_ERROR; 
+	return Status() & STATUS_ERROR;
 }
 
 
@@ -481,13 +481,13 @@ boolean SmartLCD::Error(void)
 /* Returns the keypad button pressed status where
    false = No buttons are currently pressed on the external keypad.
    true = A button on the external keypad is currently being pressed.
-   
+
    Note: Requires the optional keypad and speaker accessory to be connected to
    the Smart LCD.
 */
 boolean SmartLCD::ButtonState(void)
 {
-	return Status() & STATUS_BPS; 
+	return Status() & STATUS_BPS;
 }
 
 
@@ -500,27 +500,27 @@ boolean SmartLCD::ButtonState(void)
 		KEYPAD_RIGHT	= The right button has been pressed
 		KEYPAD_UP 		= The up button has been pressed
 		KEYPAD_LEFT 	= The left button has been pressed
-	
-	
-	After reading the button state the current status can been cleared by 
+
+
+	After reading the button state the current status can been cleared by
 	issuing the SmartLCD.ClearButton() function.
-	
+
 	Note: Requires the optional keypad and speaker accessory to be connected to
 	the Smart LCD
 */
 uint8_t	SmartLCD::Button(void)
 {
-	return Status() & STATUS_BUTTON; 
+	return Status() & STATUS_BUTTON;
 }
 
 
 
-/* Returns an 8 bit byte representing the state of the 8 bit ADC connected 
+/* Returns an 8 bit byte representing the state of the 8 bit ADC connected
    to the 'S' pin of the keypad header where:
    0 = 0V (GND) and 255 = 5V (VCC)
 
    Note this pin is used by the SmartLCD keypad for button sensing but if the
-   SmartLCD keypad is not required this pin can be used as an 8 bit ADC input 
+   SmartLCD keypad is not required this pin can be used as an 8 bit ADC input
    (5V max).
 */
 uint8_t SmartLCD::ReadADC(void)
@@ -528,7 +528,7 @@ uint8_t SmartLCD::ReadADC(void)
 	uint8_t Data = 0;
 
 	Wire.requestFrom(_I2C_Add, 2);
-	while (Wire.available()) 
+	while (Wire.available())
 	{
 		Data = Wire.read();
 	}
@@ -537,14 +537,14 @@ uint8_t SmartLCD::ReadADC(void)
 
 
 /* Returns an 8 bit byte containing the current state from the I2C status register.
-   See SmartLCD manual for an explanation of the I2C status register 
+   See SmartLCD manual for an explanation of the I2C status register
 */
 uint8_t SmartLCD::Status(void)
 {
 	uint8_t Data = 0;
 
 	Wire.requestFrom((int)_I2C_Add, 1);
-	while (Wire.available()) 
+	while (Wire.available())
 	{
 		Data = Wire.read();
 	}

--- a/SmartLCDI2C.h
+++ b/SmartLCDI2C.h
@@ -81,7 +81,7 @@ class SmartLCD
 	SmartLCD(uint8_t I2C_Add);
 	void init(void);
 	void PrintChar(char Character);
-	void Print(char *String);
+	void Print(const char *String);
 	void Print(int Value);
 	void Clear(void);
 	void CurPos(uint8_t Row, uint8_t Col);
@@ -90,7 +90,7 @@ class SmartLCD
 	void CursorBlink(uint8_t State);
 	void Backlight(uint8_t Level);
 	void PrintCustChar(uint8_t CharIndex);
-	void DefCustChar(uint8_t CharIndex, uint8_t *Data);
+	void DefCustChar(uint8_t CharIndex, const uint8_t *Data);
 	void CursorDir(uint8_t Dir);
 	void I2CInit(void);
 	void ClearButton(void);


### PR DESCRIPTION
The fix is simply to add `const` to the types pointed to in the method signatures.

With a signature like `SmartLCD::Print(char *String)` then passing `const *char` variables as arguments fails. If I replace

```C++
  SmartLCD.Print("Hello");    //Print some text
```

with

```C++
  const char *message = "Hello";
  SmartLCD.Print(message);    //Print some text
```

in `Examples/SmartLCD_Hello_World_Example/SmartLCD_Hello_World_Example.ino` compiling with arduino-cli fails like this:

```bash
$ /opt/arduino-cli_0.13.0/arduino-cli compile -b arduino:avr:uno .../arduino/sketchbook/sketch_feb02a/
.../arduino/sketchbook/sketch_feb02a/sketch_feb02a.ino: In function 'void loop()':
.../arduino/sketchbook/sketch_feb02a/sketch_feb02a.ino:20:25: error: no matching function for call to 'Print(const char*&)'
   SmartLCD.Print(message);    //Print some text
                         ^
In file included from .../arduino/sketchbook/sketch_feb02a/sketch_feb02a.ino:1:0:
.../Arduino/libraries/SmartLCD/SmartLCDI2C.h:84:7: note: candidate: void SmartLCD::Print(char*) <near match>
  void Print(char *String);
       ^~~~~
.../Arduino/libraries/SmartLCD/SmartLCDI2C.h:84:7: note:   conversion of argument 1 would be ill-formed:
.../Arduino/libraries/SmartLCD/SmartLCDI2C.h:85:7: note: candidate: void SmartLCD::Print(int) <near match>
  void Print(int Value);
       ^~~~~
.../Arduino/libraries/SmartLCD/SmartLCDI2C.h:85:7: note:   conversion of argument 1 would be ill-formed:
Error during build: exit status 1
$
```

----

(I can omit the whitespace fix commit if you like, although I think it would be nice to have fixed as well)