### PR TITLE
Fix for compiler warning when calling TwoWire::requestFrom

### DIFF
--- a/SmartLCDI2C.cpp
+++ b/SmartLCDI2C.cpp
@@ -426,9 +426,6 @@ void SmartLCD::WaitBar(uint8_t Row, uint8_t Col, uint8_t Length, uint8_t Percent
 		}
 	}while(Scale >= 5);
 
-	uint8_t Pixel = 0x10;
-
-
 	/* For the last character block it may only be partially filled so use a
 	   custom character and draw the last filled columns within the character */
 	if(Scale)

--- a/SmartLCDI2C.cpp
+++ b/SmartLCDI2C.cpp
@@ -527,7 +527,7 @@ uint8_t SmartLCD::ReadADC(void)
 {
 	uint8_t Data = 0;
 
-	Wire.requestFrom(_I2C_Add, 2);
+	Wire.requestFrom(_I2C_Add, (uint8_t)2);
 	while (Wire.available())
 	{
 		Data = Wire.read();
@@ -543,7 +543,7 @@ uint8_t SmartLCD::Status(void)
 {
 	uint8_t Data = 0;
 
-	Wire.requestFrom((int)_I2C_Add, 1);
+	Wire.requestFrom(_I2C_Add, (uint8_t)1);
 	while (Wire.available())
 	{
 		Data = Wire.read();

--- a/SmartLCDI2C.h
+++ b/SmartLCDI2C.h
@@ -116,7 +116,7 @@ class SmartLCD
 
 
   private:
-	byte _I2C_Add;
+	uint8_t _I2C_Add;
 };
 
 #endif


### PR DESCRIPTION
I have one additional fix (the last one, I do not have any more pending. Sorry for not indicating this earlier).

The TwoWire library has two signatures for `requestFrom`

```C++
uint8_t TwoWire::requestFrom(int, int);
uint8_t TwoWire::requestFrom(uint8_t, uint8_t);
```

and the compiler does not like if `requestFrom` is called with one `int` and one `uint8_t` argument.

So I changed the code so it uses `uint8_t` for both.